### PR TITLE
pip currently prefers the package name docker

### DIFF
--- a/awx/provisioning/playbook.yml
+++ b/awx/provisioning/playbook.yml
@@ -11,7 +11,8 @@
     awx_version: "devel"
     nodejs_version: "6.x"
     pip_install_packages:
-      - name: docker-py
+      - name: docker
+      - name: docker-compose
 
   roles:
     - geerlingguy.repo-epel


### PR DESCRIPTION
Attempting to build currently fails due to "docker-py" and "docker" packages both being installed. The pip error says to uninstall *both* and then reinstall just one, or else. Bizarre.

The current name of the package, from upstream Docker appears to just be "docker" and switching to install that works better. 

But then an error is generated that docker-compose is missing! So I added an explicit install for docker-compose.

It is possible that the best solution is to specify docker-compose and that will pull in the docker pip package correctly.